### PR TITLE
Comment out unused references in XML

### DIFF
--- a/draft-ietf-idr-linklocal-capability.xml
+++ b/draft-ietf-idr-linklocal-capability.xml
@@ -333,16 +333,16 @@ the invalid NEXT_HOP was received pending manual intervention.</t>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2545.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3927.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4271.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4291.xml"/>
+        <-- xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4291.xml"/ -->
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4456.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5492.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5309.xml"/>
+        <-- xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5309.xml"/ -->
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5925.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7606.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7454.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7938.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7942.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8950.xml"/>
+        <-- xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8950.xml"/ -->
       </references>
       <references>
       <name>Informative References</name>


### PR DESCRIPTION
Silences warnings from xml2rfc.  If we don't use them after document is complete, they can be fully pruned.